### PR TITLE
adjust cicd

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: e2e
+
+on:
+  pull_request:
+  repository_dispatch:
+    types: [core_pr]
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup core
+        run: |
+          cd ..
+          git clone https://github.com/flux3dp/beam-studio-core.git
+          cd beam-studio-core
+          yarn install
+      - name: Setup web
+        run: |
+          yarn install
+      - name: Run e2e tests
+        run: |
+          yarn run cy:test

--- a/.github/workflows/ready-for-deployment.yml
+++ b/.github/workflows/ready-for-deployment.yml
@@ -8,7 +8,7 @@ on:
     types: [core_merged]
 
 jobs:
-  e2e-test:
+  deployment:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,31 +21,13 @@ jobs:
       - name: Setup web
         run: |
           yarn install
-      - name: Run e2e tests
-        run: |
-          yarn run cy:test
       - name: Build artifact
         run: |
           yarn run build
-      - name: Archive production artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          retention-days: 7
-          path: |
-            dist
-  deployment:
-    needs: e2e-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: dist
       - name: Deployment via scp
         uses: garygrossgarten/github-action-scp@release
         with:
-          local: "."
+          local: dist
           remote: /var/www/beam-studio-web
           host: ${{ secrets.HOST }}
           port: ${{ secrets.PORT }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:8080"
+  "baseUrl": "http://localhost:8080",
+  "video": false
 }


### PR DESCRIPTION
changed part: move out e2e into an independent file so that each core PR is able to trigger it and can catch the problem before incorrect core PR gets merged

unchanged part: the deployment will be still triggered while there is a new web or core merge