### PR TITLE
Fix fontkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventemitter3": "^4.0.7",
     "exifr": "^7.1.3",
     "file-saver": "^2.0.5",
-    "fontkit": "^2.0.2",
+    "fontkit": "EstherFu/fontkit",
     "gl-matrix": "^3.3.0",
     "hammerjs": "^2.0.8",
     "hotkeys-js": "^3.8.7",

--- a/src/implementations/fontHelper.ts
+++ b/src/implementations/fontHelper.ts
@@ -1,3 +1,5 @@
+// TODO: Move to core
+// TODO: Add getWebFontAndUpload back
 import i18n from 'helpers/i18n';
 import {
   FontDescriptor,

--- a/src/implementations/fonts/webFonts.ts
+++ b/src/implementations/fonts/webFonts.ts
@@ -551,7 +551,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenYoGothic TW',
     italic: false,
-    postscriptName: 'GenYoGothic TW',
+    postscriptName: 'GenYoGothicTW-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenYoGothic-R.ttc',
@@ -560,7 +560,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenYoGothic TW',
     italic: false,
-    postscriptName: 'GenYoGothic TW Bold',
+    postscriptName: 'GenYoGothicTW-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenYoGothic-B.ttc',
@@ -570,7 +570,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenYoGothic JP',
     italic: false,
-    postscriptName: 'GenYoGothic JP',
+    postscriptName: 'GenYoGothicJP-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenYoGothic-R.ttc',
@@ -579,7 +579,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenYoGothic JP',
     italic: false,
-    postscriptName: 'GenYoGothic JP Bold',
+    postscriptName: 'GenYoGothicJP-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenYoGothic-B.ttc',
@@ -589,7 +589,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenRyuMin TW',
     italic: false,
-    postscriptName: 'GenRyuMin TW',
+    postscriptName: 'GenRyuMinTW-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenRyuMin-R.ttc',
@@ -598,7 +598,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenRyuMin TW',
     italic: false,
-    postscriptName: 'GenRyuMin TW Bold',
+    postscriptName: 'GenRyuMinTW-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenRyuMin-B.ttc',
@@ -608,7 +608,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenRyuMin JP',
     italic: false,
-    postscriptName: 'GenRyuMin JP',
+    postscriptName: 'GenRyuMinJP-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenRyuMin-R.ttc',
@@ -617,7 +617,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenRyuMin JP',
     italic: false,
-    postscriptName: 'GenRyuMin JP Bold',
+    postscriptName: 'GenRyuMinJP-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenRyuMin-B.ttc',
@@ -627,7 +627,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenWanMin TW',
     italic: false,
-    postscriptName: 'GenWanMin TW',
+    postscriptName: 'GenWanMinTW-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenWanMin-R.ttc',
@@ -636,7 +636,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenWanMin TW',
     italic: false,
-    postscriptName: 'GenWanMin TW Bold',
+    postscriptName: 'GenWanMinTW-SB',
     style: 'Bold',
     weight: 700,
     fileName: 'GenWanMin-SB.ttc',
@@ -646,7 +646,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenWanMin JP',
     italic: false,
-    postscriptName: 'GenWanMin JP',
+    postscriptName: 'GenWanMinJP-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenWanMin-R.ttc',
@@ -655,7 +655,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenWanMin JP',
     italic: false,
-    postscriptName: 'GenWanMin JP Bold',
+    postscriptName: 'GenWanMinJP-SB',
     style: 'Bold',
     weight: 700,
     fileName: 'GenWanMin-SB.ttc',
@@ -665,7 +665,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSekiGothic TW',
     italic: false,
-    postscriptName: 'GenSekiGothic TW',
+    postscriptName: 'GenSekiGothicTW-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenSekiGothic-R.ttc',
@@ -674,7 +674,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSekiGothic TW',
     italic: false,
-    postscriptName: 'GenSekiGothic TW Bold',
+    postscriptName: 'GenSekiGothicTW-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenSekiGothic-B.ttc',
@@ -684,7 +684,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSekiGothic JP',
     italic: false,
-    postscriptName: 'GenSekiGothic JP',
+    postscriptName: 'GenSekiGothicJP-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenSekiGothic-R.ttc',
@@ -693,7 +693,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSekiGothic JP',
     italic: false,
-    postscriptName: 'GenSekiGothic JP Bold',
+    postscriptName: 'GenSekiGothicJP-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenSekiGothic-B.ttc',
@@ -703,7 +703,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSenRounded TW',
     italic: false,
-    postscriptName: 'GenSenRounded TW',
+    postscriptName: 'GenSenRoundedTW-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenSenRounded-R.ttc',
@@ -712,7 +712,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSenRounded TW',
     italic: false,
-    postscriptName: 'GenSenRounded TW Bold',
+    postscriptName: 'GenSenRoundedTW-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenSenRounded-B.ttc',
@@ -722,7 +722,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSenRounded JP',
     italic: false,
-    postscriptName: 'GenSenRounded JP',
+    postscriptName: 'GenSenRoundedJP-R',
     style: 'Regular',
     weight: 400,
     fileName: 'GenSenRounded-R.ttc',
@@ -731,7 +731,7 @@ const fonts: WebFont[] = [
   {
     family: 'GenSenRounded JP',
     italic: false,
-    postscriptName: 'GenSenRounded JP Bold',
+    postscriptName: 'GenSenRoundedJP-B',
     style: 'Bold',
     weight: 700,
     fileName: 'GenSenRounded-B.ttc',
@@ -1537,7 +1537,7 @@ const fonts: WebFont[] = [
     postscriptName: 'Klee One Bold',
     style: 'Bold',
     weight: 700,
-    fileName: 'KleeOne-Bold.ttf',
+    fileName: 'KleeOne-SemiBold.ttf',
     supportLangs: ['zh-tw', 'ja'],
   },
   // Kaisotai

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,12 +3016,11 @@
     "@svgr/plugin-jsx" "8.1.0"
     "@svgr/plugin-svgo" "8.1.0"
 
-"@swc/helpers@^0.4.2":
-  version "0.4.36"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.36.tgz#fcfff76ed52c214f357e8e9d3f37b568908072d9"
-  integrity sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==
+"@swc/helpers@^0.5.0":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.3.tgz#98c6da1e196f5f08f977658b80d6bd941b5f294f"
+  integrity sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==
   dependencies:
-    legacy-swc-helpers "npm:@swc/helpers@=0.4.14"
     tslib "^2.4.0"
 
 "@szhsin/react-menu@^1.10.1":
@@ -6429,12 +6428,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
-fontkit@^2.0.2:
+fontkit@EstherFu/fontkit:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/fontkit/-/fontkit-2.0.2.tgz#ac5384f3ecab8327c6d2ea2e4d384afc544b48fd"
-  integrity sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==
+  resolved "https://codeload.github.com/EstherFu/fontkit/tar.gz/46bad634abd6c4265d52748a3ec4a30e676c955b"
   dependencies:
-    "@swc/helpers" "^0.4.2"
+    "@swc/helpers" "^0.5.0"
     brotli "^1.3.2"
     clone "^2.1.2"
     dfa "^1.2.0"
@@ -8202,13 +8200,6 @@ lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
-
-"legacy-swc-helpers@npm:@swc/helpers@=0.4.14":
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
-  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
-  dependencies:
-    tslib "^2.4.0"
 
 leven@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
1. Update Fontkit
2. Fix Web Font constant

Note: When using fontkit with ttc font(font collection), its postscriptName must match the one in the font file.