### PR TITLE
Add Cypress tests for element styling and drawing modes

### DIFF
--- a/cypress/e2e/canvas/drawing-continuous-or-not.spec.ts
+++ b/cypress/e2e/canvas/drawing-continuous-or-not.spec.ts
@@ -1,0 +1,74 @@
+describe('drawing continuous', () => {
+  beforeEach(() => {
+    cy.landingEditor();
+  });
+
+  it('drawing continuous', () => {
+    // Step 1: Click on the top bar menu container
+    cy.get('.menu-btn-container').click();
+
+    // Step 2: Click on the "File" submenu
+    cy.contains('div[role="menuitem"]', 'File').click();
+
+    // Step 3: Click on "Preferences"
+    cy.contains('li[role="menuitem"]', 'Preferences').click();
+
+    // Step 4: Select "On" from the dropdown    
+    cy.get('#set-continuous-drawingg').select('On');
+
+    // Step 5: Click the "Apply" button
+    cy.get('div.btn.btn-done').click();
+
+    // Step 6: Click on the left-Line
+    cy.get('#left-Line').click();
+
+    // Step 7: Draw on the canvas (line#svg_1)
+    cy.get('svg#svgcontent').trigger('mousedown', 0, 0, { force: true });
+    cy.get('svg#svgcontent').trigger('mousemove', 100, 100, { force: true });
+    cy.get('svg#svgcontent').trigger('mouseup', { force: true });
+
+    // Step 8: Draw on the canvas (line#svg_2)
+    cy.get('svg#svgcontent').trigger('mousedown', 150, 150, { force: true });
+    cy.get('svg#svgcontent').trigger('mousemove', 250, 250, { force: true });
+    cy.get('svg#svgcontent').trigger('mouseup', { force: true });
+
+    // Step 9: Check if the line#svg_1 and line#svg_2 exists
+    cy.get('#svg_1').should('exist');
+    cy.get('#svg_2').should('exist');
+  });
+
+  it('not drawing continuous', () => {
+    // Step 1: Click on the top bar menu container
+    cy.get('.menu-btn-container').click();
+
+    // Step 2: Click on the "File" submenu
+    cy.contains('div[role="menuitem"]', 'File').click();
+
+    // Step 3: Click on "Preferences"
+    cy.contains('li[role="menuitem"]', 'Preferences').click();
+
+    // Step 4: Select "On" from the dropdown    
+    cy.get('#set-continuous-drawingg').select('Off');
+
+    // Step 5: Click the "Apply" button
+    cy.get('div.btn.btn-done').click();
+
+    // Step 6: Click on the left-Line
+    cy.get('#left-Line').click();
+
+    // Step 7: Draw on the canvas (line#svg_1)
+    cy.get('svg#svgcontent').trigger('mousedown', 0, 0, { force: true });
+    cy.get('svg#svgcontent').trigger('mousemove', 100, 100, { force: true });
+    cy.get('svg#svgcontent').trigger('mouseup', { force: true });
+
+    // Step 8: Draw on the canvas (line#svg_2)
+    cy.get('svg#svgcontent').trigger('mousedown', 150, 150, { force: true });
+    cy.get('svg#svgcontent').trigger('mousemove', 250, 250, { force: true });
+    cy.get('svg#svgcontent').trigger('mouseup', { force: true });
+
+    // Step 9: Check if the line#svg_1 exists
+    cy.get('#svg_1').should('exist');
+    // Step 10: Check if the line#svg_2 not exists
+    cy.get('#svg_2').should('not.exist');
+  });
+});

--- a/cypress/e2e/canvas/element-fill-stroke.spec.ts
+++ b/cypress/e2e/canvas/element-fill-stroke.spec.ts
@@ -1,0 +1,38 @@
+describe('Element fill or stroke test', () => {
+  beforeEach(() => {
+    cy.landingEditor();
+  });
+
+  it('performs a series of clicks and checks', () => {
+    const elements = [
+      '#left-Element',
+      '#basic\\/icon-circle',
+      '#svg_1',
+      'div.tab.objects'
+    ];
+
+    const infillButtonSelector = '#infill';
+    const filledClass = 'src-web-app-views-beambox-Right-Panels-Options-Blocks-InFillBlock-module__filled--Fq1Rj';
+
+    // Click through elements
+    elements.forEach(element => {
+      cy.get(element).click();
+      cy.wait(1000);
+    });
+
+    // Check initial state of infill button
+    cy.get(`${infillButtonSelector}.${filledClass}`).should('exist');
+    cy.wait(1000);
+
+    // Toggle infill button and check states
+    for (let i = 0; i < 2; i++) {
+      cy.get(infillButtonSelector).click();
+      cy.wait(1000);
+
+      cy.get(infillButtonSelector)
+        .should('exist')
+        .and(i === 0 ? 'not.have.class' : 'have.class', filledClass);
+      cy.wait(1000);
+    }
+  });
+});

--- a/cypress/e2e/canvas/only-path-element.spec.ts
+++ b/cypress/e2e/canvas/only-path-element.spec.ts
@@ -1,0 +1,29 @@
+describe('drawing', () => {
+  beforeEach(() => {
+    cy.landingEditor();
+    cy.wait(300);
+  });
+
+  it('path element check speed is 20 or not', () => {
+    cy.clickToolBtn('Line');
+    cy.get('g#selectorParentGroup').should('have.css', 'cursor', 'crosshair');
+
+    cy.get('svg#svgcontent').trigger('mousedown', 100, 100, { force: true });
+    cy.get('svg#svgcontent').trigger('mousemove', 200, 200, { force: true });
+    cy.get('svg#svgcontent').trigger('mouseup', { force: true });
+
+    cy.get('#selectorGrip_resize_ne').first().should(($grip) => { expect($grip.attr('cx')).to.be.closeTo(301, 1); });
+    cy.get('#selectorGrip_resize_nw').first().should(($grip) => { expect($grip.attr('cx')).to.be.closeTo(100, 1); });
+
+    cy.get('#svg_1').should('exist');
+    cy.get('div.top-bar div.element-title').should('have.text', 'Layer 1 > Line');
+    cy.get('div#object-panel').should('exist');
+
+    cy.get('#speed-input')
+      .should('have.attr', 'id', 'speed-input')
+      .should('have.value', '20')
+    // .clear()
+    // .type('30')
+    // .should('have.value', '30');
+  });
+});


### PR DESCRIPTION
1. Element Fill and Stroke Tests
   - Added tests for toggling fill/stroke on different element types
   - Ensures proper class application for filled elements

2. Path Element Speed Verification
   - Implemented tests to check if the default speed for path elements is set to 20
   - Verifies correct positioning of selector grips after drawing

3. Continuous and Non-continuous Drawing Tests
   - Added tests for both continuous and non-continuous drawing modes
   - Verifies correct behavior when toggling between modes in user preferences